### PR TITLE
Add configurable accent and pace

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -220,8 +220,11 @@ function App() {
           reorderedAgents.unshift(agent);
         }
 
+        const accentPrompt =
+          'Speak with a strong New Yorker accent and a slightly faster pace.';
         reorderedAgents.forEach((agent) => {
           (agent as any).voice = selectedVoice;
+          (agent as any).instructions = `${agent.instructions}\n\n${accentPrompt}`;
         });
 
         const companyName = agentSetKey === 'customerServiceRetail'
@@ -237,6 +240,8 @@ function App() {
           extraContext: {
             addTranscriptBreadcrumb,
           },
+          speed: 1.25,
+          additionalInstructions: accentPrompt,
         });
       } catch (err) {
         console.error("Error connecting via SDK:", err);

--- a/src/app/hooks/useRealtimeSession.ts
+++ b/src/app/hooks/useRealtimeSession.ts
@@ -21,6 +21,8 @@ export interface ConnectOptions {
   audioElement?: HTMLAudioElement;
   extraContext?: Record<string, any>;
   outputGuardrails?: any[];
+  speed?: number;
+  additionalInstructions?: string;
 }
 
 export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
@@ -115,6 +117,8 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
       audioElement,
       extraContext,
       outputGuardrails,
+      speed,
+      additionalInstructions,
     }: ConnectOptions) => {
       if (sessionRef.current) return; // already connected
 
@@ -144,6 +148,10 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
           inputAudioTranscription: {
             model: 'gpt-4o-mini-transcribe',
           },
+          ...(typeof speed === 'number' ? { speed } : {}),
+          ...(additionalInstructions
+            ? { instructions: additionalInstructions }
+            : {}),
         },
         outputGuardrails: outputGuardrails ?? [],
         context: extraContext ?? {},


### PR DESCRIPTION
## Summary
- allow session speed and instructions in `useRealtimeSession`
- modify app to add fast New Yorker accent to voices `echo`, `ash`, and `verse`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e81f3959883298cbb56f9e3aef172