### PR TITLE
Add MCP server integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your_api_key
+NEXT_PUBLIC_MCP_SSE=https://sears-kairos-koyfin-mongo-mcp.ngrok.app/sse

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Transcript from "./components/Transcript";
 import Events from "./components/Events";
 import BottomToolbar from "./components/BottomToolbar";
+import MCPQuery from "./components/MCPQuery";
 
 // Types
 import { SessionStatus } from "@/app/types";
@@ -587,6 +588,8 @@ function App() {
 
         <Events isExpanded={isEventsPaneExpanded} />
       </div>
+
+      <MCPQuery />
 
       <BottomToolbar
         sessionStatus={sessionStatus}

--- a/src/app/components/MCPQuery.tsx
+++ b/src/app/components/MCPQuery.tsx
@@ -1,0 +1,50 @@
+'use client';
+import React, { useState } from 'react';
+import useMCPClient from '../hooks/useMCPClient';
+
+export default function MCPQuery() {
+  const { sendCommand, messages } = useMCPClient();
+  const [method, setMethod] = useState('');
+  const [params, setParams] = useState('{}');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    let parsed: any = {};
+    try {
+      parsed = params ? JSON.parse(params) : {};
+    } catch {
+      alert('Params must be valid JSON');
+      return;
+    }
+    if (method) sendCommand(method, parsed);
+  };
+
+  return (
+    <div className="border-t border-gray-200 p-2 text-sm">
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-2">
+        <input
+          className="border px-2 py-1 flex-1"
+          placeholder="Method"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        />
+        <input
+          className="border px-2 py-1 flex-1"
+          placeholder="Params JSON"
+          value={params}
+          onChange={(e) => setParams(e.target.value)}
+        />
+        <button className="border px-3 py-1" type="submit">
+          Send
+        </button>
+      </form>
+      <div className="max-h-40 overflow-auto bg-gray-50 p-2 text-xs">
+        {messages.map((m, i) => (
+          <pre key={i} className="mb-1 whitespace-pre-wrap break-words">
+            {JSON.stringify(m, null, 2)}
+          </pre>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/hooks/useMCPClient.ts
+++ b/src/app/hooks/useMCPClient.ts
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { createMCPClient } from '../mcp/client';
+
+export default function useMCPClient() {
+  const clientRef = useRef<ReturnType<typeof createMCPClient> | null>(null);
+  const [messages, setMessages] = useState<any[]>([]);
+
+  useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_MCP_SSE;
+    if (!url) return;
+    const client = createMCPClient(url);
+    clientRef.current = client;
+    client.onMessage((d) => setMessages((prev) => [...prev, d]));
+    client.connect();
+    return () => client.close();
+  }, []);
+
+  const sendCommand = useCallback(async (method: string, params: Record<string, any> = {}) => {
+    if (!clientRef.current) throw new Error('Client not initialized');
+    await clientRef.current.send(method, params);
+  }, []);
+
+  return { sendCommand, messages } as const;
+}

--- a/src/app/mcp/client.ts
+++ b/src/app/mcp/client.ts
@@ -1,0 +1,53 @@
+export interface MCPMessage {
+  jsonrpc: string;
+  method: string;
+  params?: Record<string, any>;
+}
+
+export function createMCPClient(url: string) {
+  let eventSource: EventSource | null = null;
+  let messagesEndpoint: string | null = null;
+  const handlers: ((data: any) => void)[] = [];
+
+  function connect() {
+    if (eventSource) return;
+    eventSource = new EventSource(url);
+    eventSource.addEventListener('endpoint', (e: MessageEvent) => {
+      const data = (e.data || '') as string;
+      try {
+        const base = new URL(url);
+        messagesEndpoint = new URL(data, base).toString();
+      } catch {
+        messagesEndpoint = null;
+      }
+    });
+    eventSource.addEventListener('message', (e: MessageEvent) => {
+      let parsed: any = e.data;
+      try {
+        parsed = JSON.parse(e.data);
+      } catch {}
+      handlers.forEach((h) => h(parsed));
+    });
+  }
+
+  async function send(method: string, params: Record<string, any> = {}) {
+    if (!messagesEndpoint) throw new Error('No active transport');
+    await fetch(messagesEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+    });
+  }
+
+  function onMessage(handler: (data: any) => void) {
+    handlers.push(handler);
+  }
+
+  function close() {
+    eventSource?.close();
+    eventSource = null;
+    messagesEndpoint = null;
+  }
+
+  return { connect, send, onMessage, close } as const;
+}


### PR DESCRIPTION
## Summary
- connect to MCP server via new client and React hook
- add MCPQuery component to send commands
- display MCP query interface in `App.tsx`
- document MCP server endpoint in `.env.sample`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e86e237448329a82c9df71efd0637